### PR TITLE
Update task_2.md

### DIFF
--- a/task_2.md
+++ b/task_2.md
@@ -32,6 +32,9 @@ mysql -u root -p
 MySQLのプロンプトが表示されたらOK
 
 パスワード変更　※8文字以上で英大文字・小文字・数字・記号を混ぜる
+
+※ # (ハッシュ) はエラーの元になるので使用しない方が吉
+
 SET PASSWORD = PASSWORD('パスワード');
 
 変更できたら
@@ -43,10 +46,8 @@ exit　で抜ける
 sudo vi /etc/my.cnf
 
 最終行に以下を追記
-character-set-server=utf8mb4
 
-[client]
-default-character-set=utf8mb4
+character-set-server=utf8mb4
 ```
 
 ```
@@ -57,11 +58,11 @@ mysql> show variables like "chara%";
 +--------------------------+----------------------------+
 | Variable_name            | Value                      |
 +--------------------------+----------------------------+
-| character_set_client     | utf8mb4                    |
-| character_set_connection | utf8mb4                    |
+| character_set_client     | utf8                       |
+| character_set_connection | utf8                       |
 | character_set_database   | utf8mb4                    |
 | character_set_filesystem | binary                     |
-| character_set_results    | utf8mb4                    |
+| character_set_results    | utf8                       |
 | character_set_server     | utf8mb4                    |
 | character_set_system     | utf8                       |
 | character_sets_dir       | /usr/share/mysql/charsets/ |
@@ -203,7 +204,7 @@ cd /tmp
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php composer-setup.php
 php -r "unlink('composer-setup.php');"
-sudo mv composer.phar /usr/local/bin/composer  
+sudo mv composer.phar /usr/local/bin/composer
 sudo chmod +x /usr/local/bin/composer
 
 cd /var/www/html


### PR DESCRIPTION
記号の所は現在パスワードといった表記にされているので問題ないとは思うのですが
自分自身#を使用したことでそれ以降の文字がコメント扱いされていたらしく、ちょっと苦戦したので追記してます。

2点目の

[client]
default-character-set=utf8mb4

についてはコマンド実行等に影響ないのですが
ターミナルからMySQLにログインすると日本語が表示できない事象になりました。
正しいのかは分かりませんが削除することで解消されたので
変更加えさせていただきました。

ご確認お願いいたします。